### PR TITLE
Adding libxslt to jenkins-slave

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,13 @@ RUN yum install -y which \
     git \
     wget \
     tar \
+    zip \
+    unzip \
     openldap-clients \
     openssl \
-    python-pip && \
-    yum clean all
+    python-pip \
+    libxslt && \
+    yum clean all 
 
 RUN pip install awscli==1.10.19
 


### PR DESCRIPTION
Installing lbixslt package which is a dependency of some of our Jenkins jobs.
This change has been tested in AWS ADOP jenkins-slave container.