### PR TITLE
Updating java and centos source image to remediate critical vulnerabi…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM centos:centos7.2.1511
+FROM centos:centos7.4.1708
 MAINTAINER "Nick Griffin" <nicholas.griffin@accenture.com>
 
 # Java Env Variables
-ENV JAVA_VERSION=1.8.0_45
-ENV JAVA_TARBALL=server-jre-8u45-linux-x64.tar.gz
+ENV JAVA_VERSION=1.8.0_192
+ENV JAVA_TARBALL=server-jre-8u192-linux-x64.tar.gz
 ENV JAVA_HOME=/opt/java/jdk${JAVA_VERSION}
 
 # Swarm Env Variables (defaults)
@@ -49,7 +49,7 @@ RUN curl -L https://github.com/docker/machine/releases/download/${DOCKER_MACHINE
 # Install Java
 RUN wget -q --no-check-certificate --directory-prefix=/tmp \
          --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" \
-            http://download.oracle.com/otn-pub/java/jdk/8u45-b14/${JAVA_TARBALL} && \
+            http://download.oracle.com/otn-pub/java/jdk/8u192-b12/750e1c8617c5452694857ad95c3ee230/${JAVA_TARBALL} && \
           mkdir -p /opt/java && \
               tar -xzf /tmp/${JAVA_TARBALL} -C /opt/java/ && \
             alternatives --install /usr/bin/java java /opt/java/jdk${JAVA_VERSION}/bin/java 100 && \


### PR DESCRIPTION
…lities

Link for the current adop-jenkins-slave:latest scan result which shows 7 critical vulnerabilities:
https://anchore.io/image/dockerhub/accenture%2Fadop-jenkins-slave%3Alatest